### PR TITLE
Introduction of redirections in some cases.

### DIFF
--- a/pypistats/views/general.py
+++ b/pypistats/views/general.py
@@ -72,6 +72,9 @@ def search(package):
         order_by(RecentDownloadCount.package).\
         limit(20).all()
     packages = [r.package for r in results]
+    if len(packages) == 1:
+        package = packages[0]
+        return redirect(f"/packages/{package}")
     return render_template(
         "search.html", search=True, form=form, packages=packages, user=g.user
     )
@@ -97,7 +100,7 @@ def package_page(package):
     recent_downloads = RecentDownloadCount.query.\
         filter_by(package=package).all()
     if len(recent_downloads) == 0:
-        abort(404)
+        return redirect(f"/search/{package}")
     recent = {r: 0 for r in RECENT_CATEGORIES}
     for r in recent_downloads:
         recent[r.category] = r.downloads


### PR DESCRIPTION
Indeed, before this patch, if we had only one result, we had to click then
we get the result. Now if there is only one package in the results, we redirect
directly to its stats page.

In the other side, I do not think that returning `404` when we requests for
example `/packages/fjwiofjowejfiewjfojio` is a good idea. That is why, I
simply added a redirection to the `/search/fjwiofjowejfiewjfojio` page in
that case.