### PR TITLE
Sort and dedupe requirements

### DIFF
--- a/pypistats/templates/package.html
+++ b/pypistats/templates/package.html
@@ -46,11 +46,7 @@
             {{ metadata['info']['version'] }}
             <br>
             {% if metadata['requires'] %}
-                Requires:
-                {% for required in metadata['requires'] %}
-                    <a href="{{ url_for('general.package_page', package=required.lower()) }}">{{ required.lower() }}</a>
-                    {% if not loop.last %}|{% endif %}
-                {% endfor %}
+                {% metadata['requires'] %}
             {% endif %}
         {% else %}
             No metadata found.

--- a/pypistats/views/general.py
+++ b/pypistats/views/general.py
@@ -117,6 +117,7 @@ def package_page(package):
 
     # PyPI metadata
     metadata = None
+    seen = set()
     if package != "__all__":
         try:
             metadata = requests.get(
@@ -125,9 +126,11 @@ def package_page(package):
             if metadata["info"].get("requires_dist", None):
                 metadata["requires"] = []
                 for required in metadata["info"]["requires_dist"]:
-                    metadata["requires"].append(
-                        re.split(r"[^0-9a-zA-Z_.-]+", required)[0]
-                    )
+                    pkg = re.split(r"[^0-9a-zA-Z_.-]+", required)[0]
+                    if pkg not in seen:
+                        metadata["requires"].append(pkg)
+                        seen.add(pkg)
+                metadata["requires"].sort()
         except Exception:
             pass
 


### PR DESCRIPTION
The current PyPIstats listing does not distinguish at all between requirements, which can be duplicated.  https://pypistats.org/packages/hypothesis provides a good example - `pytz` is listed four times!

Since working out how to display named sets of optional dependencies and environment markers for conditional dependencies is rather complicated, I settled for simply de-duplicating and sorting the existing list for clarity.

This fixes #17.