### PR TITLE
Show required vs optional deps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
   web:
     build:
       context: .
+    image: web
     command: webdev
     depends_on:
       - postgresql
@@ -30,8 +31,7 @@ services:
     volumes:
       - "./pypistats/:/app/pypistats/"
   beat:
-    build:
-      context: .
+    image: web
     command: beat
     depends_on:
       - redis
@@ -39,8 +39,7 @@ services:
     volumes:
       - "./pypistats/:/app/pypistats/"
   celery:
-    build:
-      context: .
+    image: web
     command: celery
     depends_on:
       - redis
@@ -49,8 +48,7 @@ services:
     volumes:
       - "./pypistats/:/app/pypistats/"
   flower:
-    build:
-      context: .
+    image: web
     command: flower
     depends_on:
       - redis
@@ -60,8 +58,7 @@ services:
     volumes:
       - "./pypistats/:/app/pypistats/"
   migrate:
-    build:
-      context: .
+    image: web
     command: migrate
     depends_on:
       - postgresql
@@ -70,8 +67,7 @@ services:
       - "./pypistats/:/app/pypistats/"
       - "./migrations/:/app/migrations/"
   seeds:
-    build:
-      context: .
+    image: web
     command: seeds
     depends_on:
       - postgresql

--- a/migrations/seeds.py
+++ b/migrations/seeds.py
@@ -31,6 +31,10 @@ packages = []
 for line in output.split("\n")[1:-1]:
     packages.append(line.split(" ")[0])
 
+# add some packages that have optional dependencies
+packages.append("apache-airflow")
+packages.append("databricks-dbapi")
+
 logging.info(packages)
 
 # take the last 120 days

--- a/pypistats/templates/package.html
+++ b/pypistats/templates/package.html
@@ -46,8 +46,15 @@
             {{ metadata['info']['version'] }}
             <br>
             {% if metadata['requires'] %}
-                Requires:
+                Required dependencies:
                 {% for required in metadata['requires'] %}
+                    <a href="{{ url_for('general.package_page', package=required.lower()) }}">{{ required.lower() }}</a>
+                    {% if not loop.last %}|{% endif %}
+                {% endfor %}
+            {% endif %}
+            {% if metadata['optional'] %}
+                Optional dependencies:
+                {% for required in metadata['optional'] %}
                     <a href="{{ url_for('general.package_page', package=required.lower()) }}">{{ required.lower() }}</a>
                     {% if not loop.last %}|{% endif %}
                 {% endfor %}

--- a/pypistats/templates/package.html
+++ b/pypistats/templates/package.html
@@ -53,9 +53,10 @@
                 {% endfor %}
             {% endif %}
             {% if metadata['optional'] %}
+                <br>
                 Optional dependencies:
-                {% for required in metadata['optional'] %}
-                    <a href="{{ url_for('general.package_page', package=required.lower()) }}">{{ required.lower() }}</a>
+                {% for optional in metadata['optional'] %}
+                    <a href="{{ url_for('general.package_page', package=optional.lower()) }}">{{ optional.lower() }}</a>
                     {% if not loop.last %}|{% endif %}
                 {% endfor %}
             {% endif %}

--- a/pypistats/views/general.py
+++ b/pypistats/views/general.py
@@ -114,8 +114,8 @@ def package_page(package):
             if metadata["info"].get("requires_dist", None):
                 requires, optional = set(), set()
                 for dependency in metadata["info"]["requires_dist"]:
-                    package_name = re.split(r"[^0-9a-zA-Z_.-]+", dependency)[0]
-                    if "; extra ==" in package:
+                    package_name = re.split(r"[^0-9a-zA-Z_.-]+", dependency.lower())[0]
+                    if "; extra ==" in dependency:
                         optional.add(package_name)
                     else:
                         requires.add(package_name)

--- a/pypistats/views/general.py
+++ b/pypistats/views/general.py
@@ -112,10 +112,15 @@ def package_page(package):
         try:
             metadata = requests.get(f"https://pypi.python.org/pypi/{package}/json", timeout=5).json()
             if metadata["info"].get("requires_dist", None):
-                requires = set()
-                for required in metadata["info"]["requires_dist"]:
-                    requires.add(re.split(r"[^0-9a-zA-Z_.-]+", required)[0])
-                metadata["requires"] = sorted(list(requires))
+                requires, optional = set(), set()
+                for dependency in metadata["info"]["requires_dist"]:
+                    package_name = re.split(r"[^0-9a-zA-Z_.-]+", dependency)[0]
+                    if "; extra ==" in package:
+                        optional.add(package_name)
+                    else:
+                        requires.add(package_name)
+                metadata["requires"] = sorted(requires)
+                metadata["optional"] = sorted(optional)
         except Exception:
             pass
 


### PR DESCRIPTION
`pip install x` does not install extras dependencies by default, so we'll show them in a separate list.  This is particularly useful for packages which have many optional integrations, or which track development dependencies using package extras.

This is basically a simplified version of #23, based on #31.