### PR TITLE
Smooth trailing 7days, and smooth *before* calculating proportions

### DIFF
--- a/pypistats/templates/package.html
+++ b/pypistats/templates/package.html
@@ -74,6 +74,8 @@ Downloads last week:
 <br>
 Downloads last month:
 {{ "{:,.0f}".format(recent['month']) }}
+<br>
+<input type="checkbox" id="smoothing" {{ 'checked' if metadata['use_smoothing'] else ''}} onclick="return setSmoothing();"> 7-day smoothing
 </p>
     <script>
 
@@ -101,5 +103,14 @@ Downloads last month:
                 }
             };
         })();
+
+        function setSmoothing() {
+            if (document.getElementById('smoothing').checked) {
+                window.location='{{ url_for('general.package_page', package=package) }}?smooth=true';
+            } else {
+                window.location='{{ url_for('general.package_page', package=package) }}';
+            }
+            return false;
+        }
     </script>
 {% endblock %}

--- a/pypistats/views/general.py
+++ b/pypistats/views/general.py
@@ -200,13 +200,11 @@ def smooth_data(data, window=7):
     # Ensure data is sorted by date
     data["x"], data["y"] = zip(*[(x, y) for x, y in sorted(
         zip(data["x"], data["y"]), key=lambda pair: pair[0])])
-    # Smooth data on a rolling window
+    # Smooth data with a trailing window, so recent days are as accurate as possible
     smoothed_data = deepcopy(data)
     smoothed_data["y"] = list(smoothed_data["y"])
-    for i in range(len(data["y"])):
-        window_start = max(0, i - window // 2)
-        window_end = min(len(data["y"]), i + window // 2 + 1)
-        window_data = data["y"][window_start:window_end]
+    for i in range(window, len(data["y"])):
+        window_data = data["y"][max(0, i - window):i]
         smoothed_data["y"][i] = sum(window_data) / len(window_data)
     return smoothed_data
 

--- a/pypistats/views/general.py
+++ b/pypistats/views/general.py
@@ -107,7 +107,7 @@ def package_page(package):
         recent[r.category] = r.downloads
 
     # PyPI metadata
-    metadata = None
+    metadata = dict()
     if package != "__all__":
         try:
             metadata = requests.get(f"https://pypi.python.org/pypi/{package}/json", timeout=5).json()
@@ -139,8 +139,13 @@ def package_page(package):
         else:
             metrics = ["downloads", "percentages"]
 
+        use_smoothing = metadata['use_smoothing'] = request.args.get('smooth', None) is not None
         for metric in metrics:
-            model_data.append({"metric": metric, "name": model.__tablename__, "data": data_function[metric](records)})
+            model_data.append({
+                "metric": metric,
+                "name": model.__tablename__,
+                "data": data_function[metric](records, use_smoothing=use_smoothing),
+            })
 
     # Build the plots
     plots = []
@@ -191,7 +196,22 @@ def package_page(package):
     return render_template("package.html", package=package, plots=plots, metadata=metadata, recent=recent, user=g.user)
 
 
-def get_download_data(records):
+def smooth_data(data, window=7):
+    # Ensure data is sorted by date
+    data["x"], data["y"] = zip(*[(x, y) for x, y in sorted(
+        zip(data["x"], data["y"]), key=lambda pair: pair[0])])
+    # Smooth data on a rolling window
+    smoothed_data = deepcopy(data)
+    smoothed_data["y"] = list(smoothed_data["y"])
+    for i in range(len(data["y"])):
+        window_start = max(0, i - window // 2)
+        window_end = min(len(data["y"]), i + window // 2 + 1)
+        window_data = data["y"][window_start:window_end]
+        smoothed_data["y"][i] = sum(window_data) / len(window_data)
+    return smoothed_data
+
+
+def get_download_data(records, use_smoothing=False):
     """Organize the data for the absolute plots."""
     data = defaultdict(lambda: {"x": [], "y": []})
 
@@ -241,10 +261,16 @@ def get_download_data(records):
             if category not in date_categories:
                 data[category]["x"].append(str(records[-1].date))
                 data[category]["y"].append(0)
+
+    if use_smoothing:
+        # Smooth data using a 7-day window
+        for category in all_categories:
+            data[category] = smooth_data(data[category])
+
     return data
 
 
-def get_proportion_data(records):
+def get_proportion_data(records, use_smoothing=False):
     """Organize the data for the fill plots."""
     data = defaultdict(lambda: {"x": [], "y": [], "text": []})
 
@@ -289,6 +315,11 @@ def get_proportion_data(records):
                 value = date_categories[category] / total
                 data[category]["y"].append(value)
                 data[category]["text"].append("{0:.2f}%".format(value) + " = {:,}".format(date_categories[category]))
+
+    if use_smoothing:
+        # Smooth data using a 7-day window
+        for category in all_categories:
+            data[category] = smooth_data(data[category])
 
     return data
 


### PR DESCRIPTION
Fixes #21 and closes #25 (with thanks to @scottgigante).  The two differences to #25 are that 

1. Instead of centering the smoothing window, we use the *trailing* seven days.  This means that the effect of the shorter window does not impact the most recent days of data, which is where maintainers tend to be most concerned - otherwise there would be a big dip on weekends when the window was Thurs-Sun and not yet brought back up by Mon-Tues.

2. The proportional calculations have been refactored from "average of proportions" to "proportion of averages" - which is much less impacted by random variations, and the obvious interpretation when the plain averages are visible in the previous chart.

@crflynn - I'm keen to get this merged soon, is there anything I can do to help that?