### PR TITLE
Add "access-control-allow-origin: *" header to API responses to allow…

### DIFF
--- a/pypistats/views/api.py
+++ b/pypistats/views/api.py
@@ -47,7 +47,9 @@ def api_downloads_recent(package):
     else:
         abort(404)
 
-    return jsonify(response)
+    response = jsonify(response)
+    response.headers["access-control-allow-origin"] = "*"
+    return response
 
 
 @blueprint.route("/packages/<package>/overall")
@@ -82,7 +84,9 @@ def api_downloads_overall(package):
     else:
         abort(404)
 
-    return jsonify(response)
+    response = jsonify(response)
+    response.headers["access-control-allow-origin"] = "*"
+    return response
 
 
 @blueprint.route("/packages/<package>/python_major")
@@ -120,7 +124,9 @@ def generic_downloads(model, package, arg, name):
     else:
         abort(404)
 
-    return jsonify(response)
+    response = jsonify(response)
+    response.headers["access-control-allow-origin"] = "*"
+    return response
 
 
 # TODO

--- a/pypistats/views/api.py
+++ b/pypistats/views/api.py
@@ -16,6 +16,13 @@ from pypistats.models.download import SystemDownloadCount
 blueprint = Blueprint("api", __name__, url_prefix="/api")
 
 
+def jsonify_with_cors_headers(response):
+    """JSON-ify a response and add CORS headers"""
+    response_jsonified = jsonify(response)
+    response_jsonified.headers["access-control-allow-origin"] = "*"
+    return response_jsonified
+
+
 @blueprint.route("/")
 def api():
     """Get API documentation."""
@@ -47,9 +54,7 @@ def api_downloads_recent(package):
     else:
         abort(404)
 
-    response = jsonify(response)
-    response.headers["access-control-allow-origin"] = "*"
-    return response
+    return jsonify_with_cors_headers(response)
 
 
 @blueprint.route("/packages/<package>/overall")
@@ -84,9 +89,7 @@ def api_downloads_overall(package):
     else:
         abort(404)
 
-    response = jsonify(response)
-    response.headers["access-control-allow-origin"] = "*"
-    return response
+    return jsonify_with_cors_headers(response)
 
 
 @blueprint.route("/packages/<package>/python_major")
@@ -124,9 +127,7 @@ def generic_downloads(model, package, arg, name):
     else:
         abort(404)
 
-    response = jsonify(response)
-    response.headers["access-control-allow-origin"] = "*"
-    return response
+    return jsonify_with_cors_headers(response)
 
 
 # TODO


### PR DESCRIPTION
… cross-origin web clients to use the APIs

This resolves issue #41 