### PR TITLE
Update link to psf/pypistats.org

### DIFF
--- a/pypistats/templates/about.html
+++ b/pypistats/templates/about.html
@@ -32,7 +32,7 @@
                 href="https://github.com/hugovk/pypistats"><img src="https://img.shields.io/pypi/dm/pypistats.svg"></a>
         </li>
     </ul>
-    <p>PyPIStats.org is also <a href="https://github.com/crflynn/pypistats.org">open source</a>.</p>
+    <p>PyPIStats.org is also <a href="https://github.com/psf/pypistats.org">open source</a>.</p>
     <h3>Who</h3>
     <p>PyPI Stats was created by
         <a href="https://flynn.gg">Christopher Flynn</a>.


### PR DESCRIPTION
The old https://github.com/crflynn/pypistats.org redirects to https://github.com/psf/pypistats.org so no rush.